### PR TITLE
Use patched JSGL

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Install license checker
         uses: actions/checkout@master
         with:
-          name: emeraldpay/js-green-licenses
+          repository: emeraldpay/js-green-licenses
           ref: dev
           path: jsgl
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -51,14 +51,14 @@ jobs:
 
 #       This is for the patched version
 #      ------------------------------
-      - uses: actions/checkout@master
-        name: Install license checker
+      - name: Install license checker
+        uses: actions/checkout@master
         with:
           name: emeraldpay/js-green-licenses
           ref: dev
           path: jsgl
 
-      - uses: Prepare jsgl
+      - name: Prepare jsgl
         run: |
           cd jsgl
           npm install

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -40,8 +40,32 @@ jobs:
         with:
           node-version: '18.x'
 
-      - name: Install license checker
-        run: npm install -g js-green-licenses
+#      This is for the official version
+#      ------------------------------
+#      - name: Install license checker
+#        run: npm install -g js-green-licenses
+#
+#      - name: Check licenses
+#        run: jsgl --local .
+#      ------------------------------
+
+#       This is for the patched version
+#      ------------------------------
+      - uses: actions/checkout@master
+        name: Install license checker
+        with:
+          name: emeraldpay/js-green-licenses
+          ref: dev
+          path: jsgl
+
+      - uses: Prepare jsgl
+        run: |
+          cd jsgl
+          npm install
+          npm run build
+          cd ..
 
       - name: Check licenses
-        run: jsgl --local .
+        run: node jsgl/build/src/cli.js --local .
+#      ------------------------------
+

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           cd jsgl
           npm install
-          npm run build
+          npm run compile
           cd ..
 
       - name: Check licenses


### PR DESCRIPTION
Official JSGL has an issue with version names, which is patched at https://github.com/google/js-green-licenses/pull/230 but is not merged yet. Use our patched version until it's merged and released.